### PR TITLE
Add webpage and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a basic Python project called Multibot. It is scaffolded for GitHub and ready for development.
 
+View the hardware design on [Tinkercad](https://www.tinkercad.com/things/8piVGKb7lwG-multiboard-bot).
+
 ## Getting Started
 - Ensure you have Python installed.
 - Open this project in Visual Studio Code.
@@ -17,6 +19,10 @@ python <script_name>.py
 ## Project Structure
 - `.github/copilot-instructions.md`: Copilot customization instructions.
 - `README.md`: Project overview and instructions.
+
+## Webpage
+An example webpage is available in the `docs/` folder. Once pushed to GitHub,
+you can enable GitHub Pages in the repository settings to share it publicly.
 
 ## License
 Specify your license here.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Multibot Project</title>
+</head>
+<body>
+    <h1>Multibot</h1>
+    <p>This is the Multibot project. You can see the hardware design on Tinkercad:</p>
+    <p><a href="https://www.tinkercad.com/things/8piVGKb7lwG-multiboard-bot">Tinkercad Multiboard Bot</a></p>
+    <p>Run <code>python main.py</code> to see the project in action.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- mention a Tinkercad link in the README
- add simple instructions for the webpage
- provide an example webpage with a link to Tinkercad

## Testing
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_6841da7f653083208f6517c94eadb101